### PR TITLE
Search source_ip in pptp syslog message

### DIFF
--- a/pptp.rules
+++ b/pptp.rules
@@ -26,6 +26,7 @@
 #*************************************************************
 
 alert tcp $EXTERNAL_NET any -> $HOME_NET $PPTP_PORT (msg:"[PPTP] Failed message [communications error]"; pcre: "/GRE: \S+ from \S+ failed: status = -1/"; classtype: network-event; program: pptpd; reference: url,wiki.quadrantsec.com/bin/view/Main/5000134; sid: 5000134; rev:2;)
-alert tcp $EXTERNAL_NET any -> $HOME_NET $PPTP_PORT (msg:"[PPTP] Connection established"; content: "control connection started"; classtype: successful-user; program: pptpd; reference: url,wiki.quadrantsec.com/bin/view/Main/5000135; sid:5000135; rev:2;)
+#NPF
+alert tcp $EXTERNAL_NET any -> $HOME_NET $PPTP_PORT (msg:"[PPTP] Connection established"; content: "control connection started"; classtype: successful-user; program: pptpd; reference: url,wiki.quadrantsec.com/bin/view/Main/5000135; sid:5000135; rev:2; parse_src_ip:1;)
 
 

--- a/pptp.rules
+++ b/pptp.rules
@@ -26,7 +26,6 @@
 #*************************************************************
 
 alert tcp $EXTERNAL_NET any -> $HOME_NET $PPTP_PORT (msg:"[PPTP] Failed message [communications error]"; pcre: "/GRE: \S+ from \S+ failed: status = -1/"; classtype: network-event; program: pptpd; reference: url,wiki.quadrantsec.com/bin/view/Main/5000134; sid: 5000134; rev:2;)
-#NPF
 alert tcp $EXTERNAL_NET any -> $HOME_NET $PPTP_PORT (msg:"[PPTP] Connection established"; content: "control connection started"; classtype: successful-user; program: pptpd; reference: url,wiki.quadrantsec.com/bin/view/Main/5000135; sid:5000135; rev:2; parse_src_ip:1;)
 
 


### PR DESCRIPTION
When receiving a pptp syslog message from pptp from a new connection the source ip gets wrongly parsed. I get

[**] [1:5000135] [PPTP] Connection established [**]
[Classification: successful-user] [Priority: 1] [VPN_CONCENTRATOR_IP]
2015-11-18 11:49:35 VPN_CONCENTRATOR_IP:514 -> VPN_CONCENTRATOR_IP:1723 user notice
Message:  CTRL: Client CLIENT_IP control connection started
[Xref => http://wiki.quadrantsec.com/bin/view/Main/5000135]

After the change i get:

[**] [1:5000135] [PPTP] Connection established [**]
[Classification: successful-user] [Priority: 1] [VPN_CONCENTRATOR_IP]
2015-11-19 16:13:36 CLIENT_IP:514 -> VPN_CONCENTRATOR_IP:1723 user notice
Message:  CTRL: Client CLIENT_IP control connection started
[Xref => http://wiki.quadrantsec.com/bin/view/Main/5000135]
