### PR TITLE
normalization.rulebase: user-defined type for IPv4 and IPv6

### DIFF
--- a/normalization.rulebase
+++ b/normalization.rulebase
@@ -1,4 +1,4 @@
-# version=2
+version=2
 # Sagan normalize.rulebase
 # Copyright (c) 2009-2019, Quadrant Information Security <www.quadrantsec.com>
 # All rights reserved.
@@ -28,6 +28,11 @@
 #
 #*************************************************************
 
+# IPv4 or IPv6 address
+type=@ipaddr:::ffff:%..:ipv4%
+type=@ipaddr:%..:ipv4%
+type=@ipaddr:%..:ipv6%
+
 prefix=
 
 #*****************************************************************************
@@ -37,7 +42,7 @@ prefix=
 # arpalert
 # seq=277, mac=00:01:d7:35:55:06, ip=172.22.1.53, reference=172.22.2.69, type=ip_change, dev=eth0, vendor="F5 Networks, Inc."
 
-rule=: seq=%-:word%, mac=%-:word%, ip=%src-ip:ipv4%, reference=%dst-ip:ipv4%, %-:rest%
+rule=: seq=%-:word%, mac=%-:word%, ip=%src-ip:@ipaddr%, reference=%dst-ip:@ipaddr%, %-:rest%
 
 #*****************************************************************************
 # Bro
@@ -45,7 +50,7 @@ rule=: seq=%-:word%, mac=%-:word%, ip=%src-ip:ipv4%, reference=%dst-ip:ipv4%, %-
 
 # This is a "custom" bro output Sagan uses for file hashes from Bro.
 
-rule=: files: %-:word% %-:word% %src-ip:ipv4% %dst-ip:ipv4% %-:word% %-:word% %-:number% %-:word% %mime-type:word% %-:word% %-:word% %-:word% %-:word% %-:number% %-:number% %-:number% %-:number% %-:word% %-:word% %filehash-md5:word% %filehash-sha1:word% %filehash-sha256:word% %-:rest%
+rule=: files: %-:word% %-:word% %src-ip:@ipaddr% %dst-ip:@ipaddr% %-:word% %-:word% %-:number% %-:word% %mime-type:word% %-:word% %-:word% %-:word% %-:word% %-:number% %-:number% %-:number% %-:number% %-:word% %-:word% %filehash-md5:word% %filehash-sha1:word% %filehash-sha256:word% %-:rest%
 
 #*****************************************************************************
 # Cisco 
@@ -53,21 +58,21 @@ rule=: files: %-:word% %-:word% %src-ip:ipv4% %dst-ip:ipv4% %-:word% %-:word% %-
 
 #  1w3d: %SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host 192.168.0.1
 
-rule=: %uptime:word% %authfail:word% Authentication failure for SNMP req from host %src-ip:ipv4%
+rule=: %uptime:word% %authfail:word% Authentication failure for SNMP req from host %src-ip:@ipaddr%
 
 #  Dec 26 19:59:26: %SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host 10.1.128.27
 
-rule=: %month:word% %day:word% %hour:word% %%SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host %src-ip:ipv4%
+rule=: %month:word% %day:word% %hour:word% %%SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host %src-ip:@ipaddr%
 
 # Access denied URL http://www.example.com/somethings.txt SRC 192.168.0.1 DEST 10.10.10.10 on interface inside
 
-rule=: Access denied URL %url:word% SRC %src-ip:ipv4% DEST %dst-ip:ipv4% %-:rest%
+rule=: Access denied URL %url:word% SRC %src-ip:@ipaddr% DEST %dst-ip:@ipaddr% %-:rest%
 
 # Caused by WebVPN or IPSec
 # AAA user authentication Successful : server =  10.10.10.10 : user = domain\bob
 
-rule=: AAA user authentication Successful : server =  %ip-src:ipv4% : user = %username:word%
-rule=: AAA user authentication Rejected : reason = AAA failure : server = %src-ip:ipv4% : user = %username:word%
+rule=: AAA user authentication Successful : server =  %ip-src:@ipaddr% : user = %username:word%
+rule=: AAA user authentication Rejected : reason = AAA failure : server = %src-ip:@ipaddr% : user = %username:word%
 
 # User authentication failed: Uname: timothy
 
@@ -77,32 +82,32 @@ rule=: User authentication failed: Uname: %username:word%
 # %ASA-6-315011: SSH session from 192.168.0.1  on interface Outside2 for user "test" disconnected by SSH server, reason: "Internal error" (0x00)
 #                SSH session from 10.20.10.200 on interface Outside2 for user "root" disconnected by SSH server, reason: "Internal error" (0x00)
 
-rule=: SSH session from %src-ip:ipv4% on interface %-:word% for user %username:quoted-string% disconnected by SSH server, %-:rest%
-rule=: SSH session from %src-ip:ipv4%  on interface %-:word% for user %username:quoted-string% disconnected by SSH server, %-:rest%
+rule=: SSH session from %src-ip:@ipaddr% on interface %-:word% for user %username:quoted-string% disconnected by SSH server, %-:rest%
+rule=: SSH session from %src-ip:@ipaddr%  on interface %-:word% for user %username:quoted-string% disconnected by SSH server, %-:rest%
 
-rule=: Configured from console by %-:word% (%src-ip:ipv4%)
-rule=: Authentication failure for %proto:word% req from host %src-ip:ipv4%
-rule=: Attempted to connect to %username:word% from %src-ip:ipv4%
+rule=: Configured from console by %-:word% (%src-ip:@ipaddr%)
+rule=: Authentication failure for %proto:word% req from host %src-ip:@ipaddr%
+rule=: Attempted to connect to %username:word% from %src-ip:@ipaddr%
 
 # 02:19:47.007 UTC: %SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host 10.10.10.10
 #
-rule=: %-:word% %-:word% %-:word% %-:word% %%SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host %src-ip:ipv4%
+rule=: %-:word% %-:word% %-:word% %-:word% %%SNMP-3-AUTHFAIL: Authentication failure for SNMP req from host %src-ip:@ipaddr%
 
 # Deny TCP (no connection) from perforce/139 to 192.168.73.1/2048 flags RST ACK  on interface INSIDE
 #
-rule=: Deny %proto:word% (no connection) from %src-ip:ipv4%/%src-port:number% to %dst-ip:ipv4%/%dst-port:number% flags %-:rest%
+rule=: Deny %proto:word% (no connection) from %src-ip:@ipaddr%/%src-port:number% to %dst-ip:@ipaddr%/%dst-port:number% flags %-:rest%
 
 # Mar 31 02:30:42.815 UTC: %SYS-5-CONFIG_I: Configured from console by sachen on vty0 (10.32.23.63)
 #
-rule=: %-:word% %-:word% %-:word% %-:word% %%SYS-5-CONFIG_I: Configured from console by %username:word% on %-:word% (%src-ip:ipv4%)
+rule=: %-:word% %-:word% %-:word% %-:word% %%SYS-5-CONFIG_I: Configured from console by %username:word% on %-:word% (%src-ip:@ipaddr%)
 
 # Deny inbound UDP from 46.161.166.49/63905 to 214.20.10.211/65257 on interface OUTSIDE
 #
-rule=: Deny inbound UDP from %src-ip:ipv4%/%src-port:number% to %dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Deny inbound UDP from %src-ip:@ipaddr%/%src-port:number% to %dst-ip:@ipaddr%/%dst-port:number% %-:rest%
 
 # Denied ICMP type=8, code=0 from 159.101.118.111 on interface INSIDE
 #
-rule=: Denied ICMP type=%-:number%, code=%-:number% from %src-ip:ipv4% %-:rest%
+rule=: Denied ICMP type=%-:number%, code=%-:number% from %src-ip:@ipaddr% %-:rest%
 
 # These cover a lot of WebVPN, etc rules. 
 #
@@ -116,40 +121,40 @@ rule=: Group <%-:char-to:\x3e%> User <%username:char-to:\x3e%> IP <%src-ip:char-
 # Teardown UDP connection 31929471 for inside:10.10.10.10/1111 to dmz:239.254.0.4/12224 duration 0:00:00 bytes 0
 # Teardown TCP connection 1829067148 for outside:10.10.10.10/443 to inside:192.168.1.1/10830 duration 0:03:04 bytes 8699 TCP FINs"
 
-rule=: Teardown %proto:word% connection %connection:number% for %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Teardown %proto:word% connection %connection:number% for %-:char-to:\x3a%:%src-ip:@ipaddr%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:@ipaddr%/%dst-port:number% %-:rest%
 
 # Teardown ICMP connection for faddr 10.10.10.10/0 gaddr 192.168.1.1/10000 laddr 192.168.1.1/100001
 
-rule=: Teardown %proto:word% connection for %-:word% %src-ip:ipv4%/%src-port:number% %-:word% %dst-ip:ipv4%/28694 %-:rest%
+rule=: Teardown %proto:word% connection for %-:word% %src-ip:@ipaddr%/%src-port:number% %-:word% %dst-ip:@ipaddr%/28694 %-:rest%
 
 # access-list inside_egress permitted tcp inside/10.10.10.1(10000) -> outside/192.186.1.1(80) hit-cnt 1 first hit [0xf83f456b, 0x0]
 
-rule=: access-list %-:word% permitted %proto:word% %-:char-to:\x2f%/%src-ip:ipv4%(%src-port:number%) -> %-:char-to:\x2f%/%dst-ip:ipv4%(%dst-port:number%) %-:rest%
+rule=: access-list %-:word% permitted %proto:word% %-:char-to:\x2f%/%src-ip:@ipaddr%(%src-port:number%) -> %-:char-to:\x2f%/%dst-ip:@ipaddr%(%dst-port:number%) %-:rest%
 
 # Built inbound TCP connection 3171137 for outside:10.10.10.10/10000 (10.10.10.10/10000)(DOMAIN\Bob) to inside:192.168.1.10/80 (192.168.1.1/80) (Bob)
 
-rule=: Built %-:word% %proto:word% connection %-:number% for %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% (%-:ipv4%/58521)(%domain:char-to:\x5c%\%username:char-to:\x29%) to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Built %-:word% %proto:word% connection %-:number% for %-:char-to:\x3a%:%src-ip:@ipaddr%/%src-port:number% (%-:@ipaddr%/58521)(%domain:char-to:\x5c%\%username:char-to:\x29%) to %-:char-to:\x3a%:%dst-ip:@ipaddr%/%dst-port:number% %-:rest%
 
 # Built inbound TCP connection 1834111354 for outside:10.10.10.10/28490 (10.10.10.10/28490) to dmz:192.168.1.1/80 (192.168.1.1/80)
 
-rule=: Built %-:word% %proto:word% connection %-:number% for %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% %-:word% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Built %-:word% %proto:word% connection %-:number% for %-:char-to:\x3a%:%src-ip:@ipaddr%/%src-port:number% %-:word% to %-:char-to:\x3a%:%dst-ip:@ipaddr%/%dst-port:number% %-:rest%
 
 #  Group = Employee, Username = bob, IP = 10.10.10.10, Error processing payload: Payload ID: 14
 
-rule=: Group = %-:word%, Username = %username:word%, IP = %src-ip:ipv4%, %-:rest%
-rule=: Group = %-:char-to:\x2c%, Username = %username:char-to:\x2c%, IP = %src-ip:ipv4%, %-:rest%
+rule=: Group = %-:word%, Username = %username:word%, IP = %src-ip:@ipaddr%, %-:rest%
+rule=: Group = %-:char-to:\x2c%, Username = %username:char-to:\x2c%, IP = %src-ip:@ipaddr%, %-:rest%
 
 # FTP connection from inside:10.10.1.1/3789 to outside:12.12.12.12/21, user bob Retrieved file somefile.txt
 
-rule=: FTP connection from %-:char-to:\x3a%:%src-ip:ipv4%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number%, user %username:word% %-:rest%
+rule=: FTP connection from %-:char-to:\x3a%:%src-ip:@ipaddr%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:@ipaddr%/%dst-port:number%, user %username:word% %-:rest%
 
 # TCP access denied by ACL from 10.10.10.10/28490 to inside:192.168.1.1/80
 
-rule =: TCP access denied by ACL from %src-ip:ipv4%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:ipv4%/%dst-port:number%
+rule =: TCP access denied by ACL from %src-ip:@ipaddr%/%src-port:number% to %-:char-to:\x3a%:%dst-ip:@ipaddr%/%dst-port:number%
 
 # Teardown TCP connection 361112504 for outside:10.10.1.100/61160(LOCAL\Bob) to inside:12.159.2.124/443 duration 0:00:13 bytes 3216 TCP FINs (Bob)
 
-rule=: Teardown %proto:word% connection %-:number% for outside:%src-ip:ipv4%/%src-port:number%%-:word% to inside:%dst-ip:ipv4%/%dst-port:number% %-:rest%
+rule=: Teardown %proto:word% connection %-:number% for outside:%src-ip:@ipaddr%/%src-port:number%%-:word% to inside:%dst-ip:@ipaddr%/%dst-port:number% %-:rest%
 
 # Cisco ACS normalization 
 
@@ -159,31 +164,31 @@ rule=: %-:word% %-:number% %-:number% %-:word% %-:word% %-:word% %-:word% %-:wor
 # DNS (bind, etc)
 #*****************************************************************************
 
-rule=: client %src-ip:ipv4%#%src-port:number%: update '%-:char-to:\x27%' denied
-rule=: client %src-ip:ipv4%#%src-port:number%: query (cache) '%-:char-to:\x27%' denied
-rule=: unexpected RCODE %-:word% resolving '%-:char-to:\x27%': %src-ip:ipv4%#%src-port:number%
-rule=: error (unexpected RCODE %-:word% resolving '%-:char-to:\x27%': %src-ip:ipv4%#%src-port:number%
+rule=: client %src-ip:@ipaddr%#%src-port:number%: update '%-:char-to:\x27%' denied
+rule=: client %src-ip:@ipaddr%#%src-port:number%: query (cache) '%-:char-to:\x27%' denied
+rule=: unexpected RCODE %-:word% resolving '%-:char-to:\x27%': %src-ip:@ipaddr%#%src-port:number%
+rule=: error (unexpected RCODE %-:word% resolving '%-:char-to:\x27%': %src-ip:@ipaddr%#%src-port:number%
 
 #*****************************************************************************
 # Fortinet/Fortigate
 #*****************************************************************************
 
-rule=: time=%-:word% devname=%-:word% devid=%-:word% logid=%-:word% type=%-:word% subtype=%-:word% level=%-:word% vd=%-:word% srcip=%src-ip:ipv4% srcport=%src-port:number% srcintf=%-:word% dstip=%dst-ip:ipv4% dstport=%dst-port:number% dstintf=%-:word% %-:rest% 
+rule=: time=%-:word% devname=%-:word% devid=%-:word% logid=%-:word% type=%-:word% subtype=%-:word% level=%-:word% vd=%-:word% srcip=%src-ip:@ipaddr% srcport=%src-port:number% srcintf=%-:word% dstip=%dst-ip:@ipaddr% dstport=%dst-port:number% dstintf=%-:word% %-:rest% 
 
 #*****************************************************************************
 # IMAP
 #*****************************************************************************
 
-rule=: Logout user=%username:word% host=%-:word% [%src-ip:ipv4%]
-rule=: Login excessive login failures user=%username:word% auth=%-:word% host=%-:word% [%src-ip:ipv4%]
-rule=: Login failed user=%username:word% auth=%-:word% host=%-:word% [%src-ip:ipv4%]
-rule=: authentication failure; logname= uid=%-:word% euid=%-:word% tty=%-:word% ruser=%-:word% rhost=%src-ip:ipv4% user=%username:word%
+rule=: Logout user=%username:word% host=%-:word% [%src-ip:@ipaddr%]
+rule=: Login excessive login failures user=%username:word% auth=%-:word% host=%-:word% [%src-ip:@ipaddr%]
+rule=: Login failed user=%username:word% auth=%-:word% host=%-:word% [%src-ip:@ipaddr%]
+rule=: authentication failure; logname= uid=%-:word% euid=%-:word% tty=%-:word% ruser=%-:word% rhost=%src-ip:@ipaddr% user=%username:word%
 
 #*****************************************************************************
 # Imperva
 #*****************************************************************************
 
-rule=: act=Block dst=%dst-ip:ipv4% dpt=%src-port:number% duser=%username:word% src=%src-ip:ipv4% spt=%src-port:number% proto=%proto:word% %all:rest%
+rule=: act=Block dst=%dst-ip:@ipaddr% dpt=%src-port:number% duser=%username:word% src=%src-ip:@ipaddr% spt=%src-port:number% proto=%proto:word% %all:rest%
 
 #*****************************************************************************
 # Linux kernel
@@ -196,7 +201,7 @@ rule=: act=Block dst=%dst-ip:ipv4% dpt=%src-port:number% duser=%username:word% s
 #
 # [6251572.861709] IN=fire OUT=fire PHYSIN=eth0 PHYSOUT=eth1 SRC=X.X.X.X DST=X.X.X.X LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=9133 DF PROTO=TCP SPT=50661 DPT=113 WINDOW=5840 RES=0x00 SYN URGP=0
 
-rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%src-ip:ipv4% DST=%dst-ip:ipv4% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:number% ID=%-:number% %-:word% PROTO=%proto:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
+rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%src-ip:@ipaddr% DST=%dst-ip:@ipaddr% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:number% ID=%-:number% %-:word% PROTO=%proto:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
 
 # iptables UDP : iptables flags "--state NEW,INVALID -j LOG"  (NOTE: no --prefix!)
 #
@@ -204,9 +209,9 @@ rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%s
 # [6255730.106539] IN=fire OUT=fire PHYSIN=eth0 SRC=X.X.X.X DST=X.X.X.X LEN=76 TOS=0x00 PREC=0xC0 TTL=63 ID=34162 PROTO=UDP SPT=123 DPT=123 LEN=56 
 # [6256275.991117] IN=fire OUT=fire PHYSIN=eth0 PHYSOUT=eth1 SRC=X.X.X.X DST=X.X.X.X LEN=241 TOS=0x00 PREC=0x00 TTL=64 ID=0 DF PROTO=UDP SPT=138 DPT=138 LEN=221 
 
-rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%src-ip:ipv4% DST=%dst-ip:ipv4% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:word% ID=%-:number% PROTO=%-:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
+rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% PHYSOUT=%-:word% SRC=%src-ip:@ipaddr% DST=%dst-ip:@ipaddr% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:word% ID=%-:number% PROTO=%-:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
 
-rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% SRC=%src-ip:ipv4% DST=%dst-ip:ipv4% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:number% ID=%-:number% PROTO=%proto:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
+rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% SRC=%src-ip:@ipaddr% DST=%dst-ip:@ipaddr% LEN=%-:number% TOS=%-:word% PREC=%-:word% TTL=%-:number% ID=%-:number% PROTO=%proto:word% SPT=%src-port:number% DPT=%dst-port:number% %-:rest%
 
 #*****************************************************************************
 # nfcap / nfdump 
@@ -214,41 +219,40 @@ rule=: %-:word% IN=%-:word% OUT=%-:word% PHYSIN=%-:word% SRC=%src-ip:ipv4% DST=%
 
 # source_ip: 10.1.1.1/54630, destination_ip: 12.159.2.100/13620, protocol: TCP, duration: 0.204, flags: |.A..S.|, tos: 0, packets: 2, bytes: 92, last_time: 2015-06-04 18:29:58, reported by 10.5.1.1
 
-rule=: source_ip: %src-ip:ipv4%/%src-port:number%, destination_ip: %dst-ip:ipv4%/%dst-port:number%, protocol: %proto:char-to:\x2c%, %-:rest%
+rule=: source_ip: %src-ip:@ipaddr%/%src-port:number%, destination_ip: %dst-ip:@ipaddr%/%dst-port:number%, protocol: %proto:char-to:\x2c%, %-:rest%
 
 #*****************************************************************************
 # OpenSSH
 #*****************************************************************************
 
-rule=: Failed %-:word% for invalid user %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=: Accepted %-:word% for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=: Accepted keyboard-interactive/pam for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=: Accepted password for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=: error: PAM: Authentication failure for %username:word% from %src-ip:ipv4%
+rule=: Failed %-:word% for invalid user %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2
+rule=: Accepted %-:word% for %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2
+rule=: Accepted keyboard-interactive/pam for %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2
+rule=: Accepted password for %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2
+rule=: error: PAM: Authentication failure for %username:word% from %src-ip:@ipaddr%
 rule=: error: PAM: Authentication failure for %username:word% from %src-host:word%
-rule=: pam_unix(sshd:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:ipv4%  user=%username:word%
-rule=: pam_unix(sshd:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:ipv4% 
-rule=: PAM %number:number% more authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:ipv4% 
-rule=: Accepted publickey for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2 
-rule=: error: PAM: Authentication failure for illegal user %username:word% from %src-ip:ipv4%
-rule=: Failed password for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=: Accepted gssapi-with-mic for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
-rule=: Postponed keyboard-interactive for invalid user %username:word% from %src-ip:ipv4% port %src-port:number% ssh2 [preauth]
-rule=: Failed keyboard-interactive/pam for invalid user %username:word% from %src-ip:ipv4% port %src-port:number% ssh2
+rule=: pam_unix(sshd:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:@ipaddr%  user=%username:word%
+rule=: pam_unix(sshd:auth): authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:@ipaddr% 
+rule=: PAM %number:number% more authentication failure; logname= uid=%uid:number% euid=%-:number% tty=ssh ruser= rhost=%src-ip:@ipaddr% 
+rule=: Accepted publickey for %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2%-:rest%
+rule=: error: PAM: Authentication failure for illegal user %username:word% from %src-ip:@ipaddr%
+rule=: Failed password for %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2
+rule=: Accepted gssapi-with-mic for %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2
+rule=: Postponed keyboard-interactive for invalid user %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2 [preauth]
+rule=: Failed keyboard-interactive/pam for invalid user %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2
 rule=: input_userauth_request: invalid user %username:word% [preauth]
-rule=: Invalid user %username:word% from %src-ip:ipv4%
-rule=: Disconnecting: Too many authentication failures for %username:word% from %src-ip:ipv4% port %src-port:number% ssh2 [preauth]
-rule=: Did not receive identification string from %src-ip:ipv6% port %src-port:number%
+rule=: Invalid user %username:word% from %src-ip:@ipaddr% port %src-port:number%
+rule=: Invalid user %username:word% from %src-ip:@ipaddr%
+rule=: Disconnecting: Too many authentication failures for %username:word% from %src-ip:@ipaddr% port %src-port:number% ssh2 [preauth]
+rule=: Did not receive identification string from %src-ip:@ipaddr% port %src-port:number%
 rule=: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=%src-host:word%
-rule=: Did not receive identification string from %src-p:ipv4%
-rule=: Did not receive identification string from %src-ip:ipv6%
-rule=: Bad protocol version identification '%-:char-to:\x27%' from %src-ip:ipv4% port %src-port:number%
-rule=: Bad protocol version identification '%-:char-to:\x27%' from %src-ip:ipv6% port %src-port:number%
-rule=: Bad protocol version identification '' from %src-ip:ipv4% port %src-port:number%
-rule=: Bad protocol version identification '' from %src-ip:ipv6% port %src-port:number%
+rule=: Did not receive identification string from %src-ip:@ipaddr%
+rule=: Bad protocol version identification '%-:char-to:\x27%' from %src-ip:@ipaddr% port %src-port:number%
+rule=: Bad protocol version identification '' from %src-ip:@ipaddr% port %src-port:number%
 rule=: password check failed for user (%src-ip:char-to:\x29%)
-rule=: User %username:word% from %src-ip:ipv4% not allowed %-:rest%
-rule=: User %username:word% from %src-ip:ipv6% not allowed %-:rest%
+rule=: User %username:word% from %src-ip:@ipaddr% not allowed %-:rest%
+rule=: Disconnected from user %username:word% %src-ip:@ipaddr% port %src-port:number%
+rule=: Connection closed by invalid user %username:word% %src-ip:@ipaddr% port %src-port:number% [preauth]
 
 #*****************************************************************************
 # Palo-Alto
@@ -266,40 +270,40 @@ rule=: User %username:word% from %src-ip:ipv6% not allowed %-:rest%
 #prefix= %-:number,%date:date-iso% %time:time-24hr%,%devserial:char-sep:\x2C%,
 prefix= %time:time-24hr%,%devserial:char-sep:\x2C%,
 
-rule=url-log,pattern4:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%http_uri:char-sep:\x2C%,(9999),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%,
+rule=url-log,pattern4:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%http_uri:char-sep:\x2C%,(9999),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%,
 
-rule=url-log,pattern1:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:char-sep:\x2C%,%natdstip:char-sep:\x2C%,%policy:char-sep:\x2C%,%source_user:char-sep:\x2C%,%destination_user:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session_id:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:char-sep:\x2C%,%nat-dst-port:char-sep:\x2C%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:quoted-string%,(%threatid:char-sep:\x2C%),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=url-log,pattern1:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:char-sep:\x2C%,%natdstip:char-sep:\x2C%,%policy:char-sep:\x2C%,%source_user:char-sep:\x2C%,%destination_user:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session_id:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:char-sep:\x2C%,%nat-dst-port:char-sep:\x2C%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:quoted-string%,(%threatid:char-sep:\x2C%),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=url-log,pattern2:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:char-sep:\x28%,%ips-threat-id:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=url-log,pattern2:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:char-sep:\x28%,%ips-threat-id:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=url-log,pattern3:THREAT,url,%-:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:char-sep:\x22\x2C\x28%,(%ips-threat-id:char-sep:\x28%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%unusedfield:char-sep:\x2C%,%content-type:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%therest:rest%
+rule=url-log,pattern3:THREAT,url,%-:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:char-sep:\x22\x2C\x28%,(%ips-threat-id:char-sep:\x28%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%unusedfield:char-sep:\x2C%,%content-type:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%therest:rest%
 
-rule=url-log,pattern5:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:quoted-string%,(9999),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=url-log,pattern5:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:quoted-string%,(9999),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=url-log,pattern6:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:quoted-string%,%ips-threat-id:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=url-log,pattern6:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:quoted-string%,%ips-threat-id:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=url-log,pattern7:THREAT,url,%-:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,\"%url:char-sep:\x22\x2C%\",(%ips-threat-id:char-sep:\x28%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%unusedfield:char-sep:\x2C%,%content-type:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%therest:rest%
+rule=url-log,pattern7:THREAT,url,%-:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,\"%url:char-sep:\x22\x2C%\",(%ips-threat-id:char-sep:\x28%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%unusedfield:char-sep:\x2C%,%content-type:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%therest:rest%
 
-rule=virus,pattern1:THREAT,virus,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,0x%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%virusinfo:quoted-string%,%virusname:char-sep:(%(%threat:number%),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=virus,pattern1:THREAT,virus,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,0x%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%virusinfo:quoted-string%,%virusname:char-sep:(%(%threat:number%),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=vulnerability,pattern1:THREAT,vulnerability,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%vulname:quoted-string%,%vulnmsg:char-sep:(%(%threat:number%),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=vulnerability,pattern1:THREAT,vulnerability,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%vulname:quoted-string%,%vulnmsg:char-sep:(%(%threat:number%),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=vulnerability,pattern2:THREAT,vulnerability,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%vulname:quoted-string%,%vulnmsg:char-sep:(%(%threat:number%),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=vulnerability,pattern2:THREAT,vulnerability,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%vulname:quoted-string%,%vulnmsg:char-sep:(%(%threat:number%),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=file-detection,pattern1:THREAT,file,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%filename:quoted-string%,%filetype:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=file-detection,pattern1:THREAT,file,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%filename:quoted-string%,%filetype:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=spyware,pattern1:THREAT,spyware,%-:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%vulname:char-sep:\x2C%,%vulnmsg:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=spyware,pattern1:THREAT,spyware,%-:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%vulname:char-sep:\x2C%,%vulnmsg:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=spyware-dns,pattern1:THREAT,spyware,%-:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%vulname:quoted-string%,%vulnmsg:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=spyware-dns,pattern1:THREAT,spyware,%-:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%vulname:quoted-string%,%vulnmsg:char-sep:\x2C%,%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
-rule=traffic,pattern1:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%,%therest:rest%
+rule=traffic,pattern1:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%,%therest:rest%
 
-rule=traffic,pattern2:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%
+rule=traffic,pattern2:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%
 
-rule=traffic,pattern33:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%,%therest:rest%
+rule=traffic,pattern33:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%,%therest:rest%
 
-rule=traffic,pattern44:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%
-rule=: %time:time-24hr%,%devserial:char-sep:\x2C%,url-log,pattern4:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:ipv4%,%dst-ip:ipv4%,%natsrcip:ipv4%,%natdstip:ipv4%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:char-sep:\x2C%,(9999),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
+rule=traffic,pattern44:TRAFFIC,%subtype:char-sep:\x2C%,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%flags:char-sep:\x2C%,%proto:char-sep:\x2C%,%action:char-sep:\x2C%,%bytes:number%,%bytes_sent:number%,%bytes_received:number%,%packets:number%,%start_time:char-sep:\x2C%,%elapsed_time:number%,%url_category:char-sep:\x2C%,%-:char-sep:\x2C%,%sequence_number:number%,%panorama_flags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%-:char-sep:\x2C%,%packets_sent:number%,%packets_received:number%
+rule=: %time:time-24hr%,%devserial:char-sep:\x2C%,url-log,pattern4:THREAT,url,%dtm:char-sep:\x2C%,%genyear:number%/%genmonth:number%/%genday:number% %gentime:time-24hr%,%src-ip:@ipaddr%,%dst-ip:@ipaddr%,%natsrcip:@ipaddr%,%natdstip:@ipaddr%,%policy:char-sep:\x2C%,%-:char-sep:\x2C%,%-:char-sep:\x2C%,%app:char-sep:\x2C%,%vsys:char-sep:\x2C%,%srczone:char-sep:\x2C%,%dstzone:char-sep:\x2C%,%srcintf:char-sep:\x2C%,%dstintf:char-sep:\x2C%,%logprofile:char-sep:\x2C%,%year:number%/%month:number%/%day:number% %time:time-24hr%,%session:number%,%count:number%,%src-port:number%,%dst-port:number%,%nat-src-port:number%,%nat-dst-port:number%,%flags:char-sep:\x2C%,tcp,%action:char-sep:\x2C%,%url:char-sep:\x2C%,(9999),%url-catagory:char-sep:\x2C%,%severity:char-sep:\x2C%,%direction:char-sep:\x2C%,%sequence_number:number%,%actionflags:char-sep:\x2C%,%geo_source:char-sep:\x2C%,%geo_dest:char-sep:\x2C%,%therest:rest%
 
 #******************
 #SET EMPTY PREFIX
@@ -316,15 +320,15 @@ rule=:  port %-:number% - Security Violation
 # SMTP 
 #*****************************************************************************
 
-rule=: %-:word% %-:word% [%src-ip:ipv4%]: expn %username:word%
+rule=: %-:word% %-:word% [%src-ip:@ipaddr%]: expn %username:word%
 
 # p0IGs29E022795: ruleset=check_rcpt, arg1=<bob@example.com>, relay=mailhost.example.com [192.168.0.1], reject=553 5.1.8 <frank@example.com>... Domain of sender address bogus@example.com does not exist
 
-rule=: %-:word% ruleset=check_rcpt, %-:word% relay=%y:word% [%src-ip:ipv4%] (may be forged), reject=%-:number% %-:rest%
+rule=: %-:word% ruleset=check_rcpt, %-:word% relay=%y:word% [%src-ip:@ipaddr%] (may be forged), reject=%-:number% %-:rest%
 
 # p0I3FCpA013475: [192.168.0.1]: Possible SMTP RCPT flood, throttling.
 
-rule=: %-:word%: [%src-ip:ipv4%]: Possible SMTP RCPT flood, throttling.
+rule=: %-:word%: [%src-ip:@ipaddr%]: Possible SMTP RCPT flood, throttling.
 
 #*****************************************************************************
 # Snort
@@ -333,11 +337,11 @@ rule=: %-:word%: [%src-ip:ipv4%]: Possible SMTP RCPT flood, throttling.
 # Jun  2 00:41:47 demo snort: [1:19559:5] INDICATOR-SCAN SSH brute force login attempt [Classification: Misc activity] [Priority: 3] {TCP} 43.255.188.148:35236 -> 10.5.1.3:22
 
 
-rule=: [%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x5b%[Classification: %classtype:char-to:\x5d%] [Priority: %pri:number%] {%proto:char-to:\x7d%} %src-ip:ipv4%:%src-port:number% -> %dst-ip:ipv4%:%dst-port:number%
+rule=: [%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x5b%[Classification: %classtype:char-to:\x5d%] [Priority: %pri:number%] {%proto:char-to:\x7d%} %src-ip:@ipaddr%:%src-port:number% -> %dst-ip:@ipaddr%:%dst-port:number%
 
 # Appears the later version of Snort add a : after the "Priority" field. 
 
-rule=: [%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x5b%[Classification: %classtype:char-to:\x5d%] [Priority: %pri:number%]: {%proto:char-to:\x7d%} %src-ip:ipv4%:%src-port:number% -> %dst-ip:ipv4%:%dst-port:number%
+rule=: [%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x5b%[Classification: %classtype:char-to:\x5d%] [Priority: %pri:number%]: {%proto:char-to:\x7d%} %src-ip:@ipaddr%:%src-port:number% -> %dst-ip:@ipaddr%:%dst-port:number%
 
 
 #*****************************************************************************
@@ -346,11 +350,11 @@ rule=: [%generator_id:number%:%sig_id:number%:%rev:number%] %sig_name:char-to:\x
 
 # Remember the space at the end of the rule..  Also " counts as part of a %thing:word%
 
-rule=: id=%firewall:word% sn=%serial:word% time="%date:date-iso% %time:time-24hr%" fw=%fire-ip:ipv4% pri=%pri:number% c=%c:number% m=%m:number% msg="Possible port scan detected" n=%n:number% src=%src-ip:ipv4%:%src-port:number%:%interface:word% dst=%dst-ip:ipv4%:%dst-port:number%:%interface:word% note=%ports-scanned:quoted-string% 
+rule=: id=%firewall:word% sn=%serial:word% time="%date:date-iso% %time:time-24hr%" fw=%fire-ip:@ipaddr% pri=%pri:number% c=%c:number% m=%m:number% msg="Possible port scan detected" n=%n:number% src=%src-ip:@ipaddr%:%src-port:number%:%interface:word% dst=%dst-ip:@ipaddr%:%dst-port:number%:%interface:word% note=%ports-scanned:quoted-string% 
 
-#rule=:  msg="%alert:char-to:\x22%" sid=%sid:number% ipscat=%proto:word% ipspri=%ipspri:number% n=%n:number% src=%src-ip:ipv4%:%src-port:number%:%interface:word% dst=%dst-ip:ipv4%:%dst-port:number%:%interface:word% 
+#rule=:  msg="%alert:char-to:\x22%" sid=%sid:number% ipscat=%proto:word% ipspri=%ipspri:number% n=%n:number% src=%src-ip:@ipaddr%:%src-port:number%:%interface:word% dst=%dst-ip:@ipaddr%:%dst-port:number%:%interface:word% 
 
-rule=: id=%firewall:word% sn=%serial:word% time="%date:date-iso% %time:time-24hr%" fw=%fire-ip:ipv4% pri=%pri:number% c=%c:number% m=%m:number% msg=%alert:quoted-string% sid=%sid:number% ipscat=%proto:word% ipspri=%ipspri:number% n=%n:number% src=%src-ip:ipv4%:%src-port:number%:%interface:word% dst=%dst-ip:ipv4%:%dst-port:number%:%interface:word% 
+rule=: id=%firewall:word% sn=%serial:word% time="%date:date-iso% %time:time-24hr%" fw=%fire-ip:@ipaddr% pri=%pri:number% c=%c:number% m=%m:number% msg=%alert:quoted-string% sid=%sid:number% ipscat=%proto:word% ipspri=%ipspri:number% n=%n:number% src=%src-ip:@ipaddr%:%src-port:number%:%interface:word% dst=%dst-ip:@ipaddr%:%dst-port:number%:%interface:word% 
 
 #*****************************************************************************
 # su/sudo
@@ -375,7 +379,7 @@ rule=: auth failed on module %-:word% from %-:word% (%src-ip:char-to:\x29%): %-:
 # VMWare (ESXi, etc)
 #*****************************************************************************
 
-rule=: Accepted password for %username:word% from %src-ip:ipv4%
+rule=: Accepted password for %username:word% from %src-ip:@ipaddr%
 
 #*****************************************************************************
 # Microsoft Windows (via Evt2sys or NXLog
@@ -383,9 +387,9 @@ rule=: Accepted password for %username:word% from %src-ip:ipv4%
 
 # Note the space at the end!
 #
-#rule=: 529: NT AUTHORITY\\SYSTEM: Logon Failure: Reason: Unknown user name or bad password User Name: %username:word% Domain: %-:word% Logon Type: 3 Logon Process: NtLmSsp Authentication Package: NTLM Workstation Name: %-:word% Caller User Name: - Caller Domain: - Caller Logon ID: - Caller Process ID: - Transited Services: - Source Network Address: %src-ip:ipv4% Source Port: %src-port:number% 
+#rule=: 529: NT AUTHORITY\\SYSTEM: Logon Failure: Reason: Unknown user name or bad password User Name: %username:word% Domain: %-:word% Logon Type: 3 Logon Process: NtLmSsp Authentication Package: NTLM Workstation Name: %-:word% Caller User Name: - Caller Domain: - Caller Logon ID: - Caller Process ID: - Transited Services: - Source Network Address: %src-ip:@ipaddr% Source Port: %src-port:number% 
 
-#rule=: 529: S-1-5-18: Logon Failure: Reason: Unknown user name or bad password User Name: %username:word% Domain: %-:word% Logon Type: 3 Logon Process: NtLmSsp Authentication Package: NTLM Workstation Name: %-:word% Caller User Name: - Caller Domain: - Caller Logon ID: - Caller Process ID: - Transited Services: - Source Network Address: %src-ip:ipv4% Source Port: %src-port:number% 
+#rule=: 529: S-1-5-18: Logon Failure: Reason: Unknown user name or bad password User Name: %username:word% Domain: %-:word% Logon Type: 3 Logon Process: NtLmSsp Authentication Package: NTLM Workstation Name: %-:word% Caller User Name: - Caller Domain: - Caller Logon ID: - Caller Process ID: - Transited Services: - Source Network Address: %src-ip:@ipaddr% Source Port: %src-port:number% 
 
 #*****************************************************************************
 # Citrix
@@ -393,18 +397,18 @@ rule=: Accepted password for %username:word% from %src-ip:ipv4%
 
 #  16:04:31 GMT server1 PPE-1 : AAA LOGIN_FAILED 71011157 :  User bob - Client_ip 12.12.12.12 - Failure_reason "External authentication server denied access"
 
-rule=: %-:word% %-:word% %-:word% %-:word% : AAA LOGIN_FAILED %-:word% :  User %username:word% - Client_ip %src-ip:ipv4% - Failure_reason %-:rest%
+rule=: %-:word% %-:word% %-:word% %-:word% : AAA LOGIN_FAILED %-:word% :  User %username:word% - Client_ip %src-ip:@ipaddr% - Failure_reason %-:rest%
 
 #  16:23:29 GMT server1 PPE-0 : SSLVPN LOGIN 75181906 : Context bob@12.12.12.12 - SessionId: 11147- User bob - Client_ip 12.12.12.12 - Nat_ip "Mapped Ip" - Vserver 192.168.1.1:443 - Browser_type "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)" - SSLVPN_client_type Clientless - Group(s) "N/A"
 
-rule=: %-:word% %-:word% %-:word% %-:word% : SSLVPN LOGIN %-:number% : Context %-:word% - SessionId: %-:word% User %username:word% - Client_ip %src-ip:ipv4% %-:rest%
-rule=: %-:word% %-:word% %-:word% %-:word% : SSLVPN LOGOUT %-:number% : Context %-:word% - SessionId: %-:word% User %username:word% - Client_ip %src-ip:ipv4% %-:rest%
+rule=: %-:word% %-:word% %-:word% %-:word% : SSLVPN LOGIN %-:number% : Context %-:word% - SessionId: %-:word% User %username:word% - Client_ip %src-ip:@ipaddr% %-:rest%
+rule=: %-:word% %-:word% %-:word% %-:word% : SSLVPN LOGOUT %-:number% : Context %-:word% - SessionId: %-:word% User %username:word% - Client_ip %src-ip:@ipaddr% %-:rest%
 
 # New normalization rules from Sam Castellango (2017/11/07)
 
 # This is for Microsoft Windows event 4624: 
 
-rule=: %-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %Username:word% %-:string-to:Network Address:%Network Address: %Src-IP:ipv4% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %Username:word% %-:string-to:Network Address:%Network Address: %Src-IP:@ipaddr% %-:rest%
 
 # Palo Alto Firewall 
 
@@ -416,11 +420,11 @@ rule=: %-:string-to:User%User %username:word% %-:char-to:\\%\ %src-ip:char-to:\x
 
 # 10.1.11.1|syslog|info|info|2e|2017-01-28|01:19:00|01342| auth: User 'frank' logged in from 10.1.1.1 to SSH session
 
-rule=: %-:string-to:User%User %username:word% logged in from %src-ip:ipv4% %-:rest%
+rule=: %-:string-to:User%User %username:word% logged in from %src-ip:@ipaddr% %-:rest%
 
 # This is for Microsoft Windows event 4769:
 
-rule=: %-:string-to:Account Name:%Account Name: %username:char-to:\x40%%-:string-to:Client Address:%Client Address: ::ffff:%src-ip:ipv4% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %username:char-to:\x40%%-:string-to:Client Address:%Client Address: %src-ip:@ipaddr% %-:rest%
 
 # Added 2017/02/06
 
@@ -435,7 +439,7 @@ rule=: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Cal
 
 # Zscaler rule update 
 
-rule=: act=Blocked%-:string-to:dst=%dst=%dst-ip:ipv4% src=%src-ip:ipv4%%-:string-to:suser=%suser=%username:char-to:\x40%%-:rest%
+rule=: act=Blocked%-:string-to:dst=%dst=%dst-ip:@ipaddr% src=%src-ip:@ipaddr%%-:string-to:suser=%suser=%username:char-to:\x40%%-:rest%
 
 #Cylance rule update
 
@@ -458,12 +462,12 @@ rule=: 4740: A user account was locked out. %-:string-to:Locked Out%%-:string-to
 #Kerberos ticket request
 #10.21.8.10.log:10.21.8.10|user|info|info|0e|2017-08-30|10:16:31|Security| 4769: A Kerberos service ticket was requested. Account Information: Account Name: XXX@XXXXX Account Domain: XXXXXX Logon GUID: {B7666966-6666-6666-6666-666666666666} Service Information: Service Name: XXXXXX$ Service ID: S-1-5-21-1716666666-1105666666-319566666-1166666 Network Information: Client Address: ::ffff:172.27.1.1 Client Port: 49350 Additional Information: Ticket Options: 0x40810000 Ticket Encryption Type: 0x12 Failure Code: 0x0 Transited Services: - This event is generated every time access is requested to a resource such as a computer or a Windows service. The service name indicates the resource to which access was requested. This event can be correlated with Windows logon events by comparing the Logon GUID fields in each event. The logon event occurs on the machine that was accessed, which is often a different machine than the domain controller which issued the service ticket. Ticket options, encryption types, and failure codes are defined in RFC 4120.
 
-rule=: %-:string-to:Account Name:%Account Name: %username:char-to:\x40%%-:string-to:Client Address:%Client Address: ::ffff:%src-ip:ipv4% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %username:char-to:\x40%%-:string-to:Client Address:%Client Address: %src-ip:@ipaddr% %-:rest%
 
 # SSH login
 #10.144.11.8|syslog|info|info|2e|2017-08-28|09:49:19|03362| auth: User 'XXXXXX' logged in from 10.10.10.10 to SSH session
 
-rule=: %-:string-to:User%User %username:word% logged in from %src-ip:ipv4% %-:rest%
+rule=: %-:string-to:User%User %username:word% logged in from %src-ip:@ipaddr% %-:rest%
 
 #10.78.11.51|user|info|info|0e|2017-08-28|13:20:31|1,2017/08/28| 13:20:31,0008C101111,SYSTEM,general,0,2017/08/28 13:20:31,,general,,0,0,general,informational,User XXXXXX logged in via CLI from \ j10.10.10.10,809792,0x0,0,0,0,0,,XXXXXX
 
@@ -472,7 +476,7 @@ rule=: %-:string-to:User%User %username:word% %-:char-to:\\%\ %src-ip:char-to:\x
 # Account logged on - Windows event id 4624
 #10.41.43.253|user|info|info|0e|2017-08-28|13:02:55|Security| 4624: An account was successfully logged on. Subject: Security ID: S-1-0-0 Account Name: - Account Domain: - Logon ID: 0x0 Logon Type: 3 Impersonation Level: Impersonation New Logon: Security ID: S-1-5-21-2466666666-3858666666-3953666666-130966 Account Name: xxxx Account Domain: XXXXXX Logon ID: 0x5A31095D Logon GUID: {55555555-5555-5553-6666-966666666666} Process Information: Process ID: 0x0 Process Name: - Network Information: Workstation Name: - Source Network Address: 10.10.10.10 Source Port: 52526 Detailed Authentication Information: Logon Process: Kerberos Authentication Package: Kerberos Transited Services: - Package Name (NTLM only): - Key Length: 0 This event is generated when a logon session is created. It is generated on the computer that was accessed. The subject fields indicate the account on the local system which requested the logon. This is most commonly a service such as the Server service, or a local process such as Winlogon.exe or Services.exe. The logon type field indicates the kind of logon that occurred. The most common types are 2 (interactive) and 3 (network). The New Logon fields indicate the account for whom the new logon was created, i.e. the account that was logged on. The network fields indicate where a remote logon request originated. Workstation name is not always available and may be left blank in some cases. The impersonation level field indicates the extent to which a process in the logon session can impersonate. The authentication information fields provide detailed information about this specific logon request. - Logon GUID is a unique identifier that can be used to correlate this event with a KDC event. - Transited services indicate which intermediate services have participated in this logon request. - Package name indicates which sub-protocol was used among the NTLM protocols. - Key length indicates the length of the generated session key. This will be 0 if no session key was requested.
 
-rule=: %-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Network Address:%Network Address: %src-ip:ipv4% %-:rest%
+rule=: %-:string-to:Account Name:%Account Name: %-:string-to:Account Name:%Account Name: %username:word% %-:string-to:Network Address:%Network Address: %src-ip:@ipaddr% %-:rest%
 
 #*****************************************************************************
 # AS/400 rules (as400.rules)
@@ -486,7 +490,7 @@ rule=: iSecurity/Audit: %-:word% %-:word% *SECURITY User %username:word% %-:rest
 # TACACS
 #*****************************************************************************
 
-rule=: TACACS+ Client: Authentication error. Server is %DSTIP:ipv4%, user name is '%username:char-to:\x27%', remote address is %src-ip:ipv4%. %-:rest%
+rule=: TACACS+ Client: Authentication error. Server is %DSTIP:@ipaddr%, user name is '%username:char-to:\x27%', remote address is %src-ip:@ipaddr%. %-:rest%
 
 
 #*****************************************************************************
@@ -495,19 +499,11 @@ rule=: TACACS+ Client: Authentication error. Server is %DSTIP:ipv4%, user name i
 
 # 18456:
 
-rule=: %eventid:word% Login failed for user '%username:char-to:\x27%'. Reason: Could not find a login matching the name provided. [CLIENT: %src-ip:ipv4%]
+rule=: %eventid:word% Login failed for user '%username:char-to:\x27%'. Reason: Could not find a login matching the name provided. [CLIENT: %src-ip:@ipaddr%]
 
-# 4771: - IPv4 in IPv6
+# 4771:
 
-rule=: %eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: ::ffff:%src-ip:ipv4% Client Port: %src-port:number% %-:rest%
-
-# 4771: -IPv4
-
-rule=: %eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: %src-ip:ipv4% Client Port: %src-port:number% %-:rest%
-
-# 4771: - IPv6
-
-rule=: %eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: %src-ip:ipv6% Client Port: %src-port:number% %-:rest%
+rule=: %eventid:word% Kerberos pre-authentication failed. Account Information: Security ID: %ID:word% Account Name: %username:word% Service Information: Service Name: %-:word% Network Information: Client Address: %src-ip:@ipaddr% Client Port: %src-port:number% %-:rest%
 
 # 4776:
 
@@ -517,10 +513,6 @@ rule=: %-:word% A user account was unlocked. Subject: Security ID: %-:word% Acco
 
 # PAM 
 
-rule=: PAM %-:number% more authentication failures; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv4%  user=%username:word%
-rule=: PAM %-:number% more authentication failures; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv6%  user=%username:word%
-rule=: PAM %-:number% more authentication failure; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv4%  user=%username:word%
-rule=: PAM %-:number% more authentication failure; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:ipv6%  user=%username:word%
-
-rule=: error: PAM: Authentication failure for %username:word% from %src-ip:ipv6%
+rule=: PAM %-:number% more authentication failures; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:@ipaddr%  user=%username:word%
+rule=: PAM %-:number% more authentication failure; logname= %-:word% %-:word% tty=ssh ruser= rhost=%src-ip:@ipaddr%  user=%username:word%
 


### PR DESCRIPTION
This adds IPv6 support to some existing IPv4-only rules and removes some duplication.   `::ffff:1.2.3.4` is also recognised everywhere automatically as IPv4.

NOTE: It was necessary to uncomment "version=2" at the top of the file to enable the user-defined types feature.  v2 rulebase is more or less [compatible](https://www.liblognorm.com/files/manual/configuration.html#legacy-format) with v1, but there is a risk of some breakage if some [rarely-used features](https://www.liblognorm.com/files/manual/configuration.html#rulebase-versions) of the v1 ruleset are in use.  I can't see any.

Also includes some ssh normalization fixes/additions:
- Accepted publickey ... was missing %-:rest% at the end
- Invalid user ... port %src-port:number%
- Disconnected from user ...
- Connection closed by invalid user ...

Fixes #29